### PR TITLE
Fix path in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM ubuntu:latest
 RUN apt-get update
 RUN apt-get -y install curl git
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh
-ENTRYPOINT ["/root/.deno/bin/deno", "--allow-read", "--allow-run", "https://deno.land/x/license_checker@v2.0.0/main.ts"]
+ENTRYPOINT ["/root/.local/bin/deno", "--allow-read", "--allow-run", "https://deno.land/x/license_checker@v2.0.0/main.ts"]


### PR DESCRIPTION
The `/root/.deno` is not the correct directory. The checker is in `/root/.local`.